### PR TITLE
新規投稿の際にもアクティブハッシュを渡す

### DIFF
--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -1,5 +1,5 @@
 class PromptsController < ApplicationController
-  before_action :retribute_active_hash, only: [:index, :new, :edit, :update, :show]
+  before_action :retribute_active_hash, only: [:index, :new, :create, :edit, :update, :show]
   before_action :set_prompt, only: [:edit, :update, :destroy, :show]
   before_action :authenticate_ip!, only: [:edit, :update, :destroy]
   def index


### PR DESCRIPTION
# What
投稿時、エラー文出力を実装
activehashを実装するcreateアクションに渡した。
# Why
投稿をできない原因をuserに伝えるため。