### PR TITLE
nick_nameを2回目の投稿以降再利用可能に

### DIFF
--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -13,6 +13,7 @@ class PromptsController < ApplicationController
   def create
     @prompt = Prompt.new(prompt_params)
     if @prompt.save
+      cookies[:last_nick_name] = prompt_params[:nick_name]
       redirect_to root_path
     else
       render action: :new, status: :unprocessable_entity

--- a/app/views/prompts/_form.html.erb
+++ b/app/views/prompts/_form.html.erb
@@ -12,7 +12,7 @@
   </div>
   <div class="prompt-nick-name-form">
     <span>投稿者名</span>
-    <%=form.text_field :nick_name%>
+    <%=form.text_field :nick_name, value: cookies[:last_nick_name] %>
   </div>
   <div class="prompt-ai-name-form">
     <span>プロンプトを適用したAI</span>


### PR DESCRIPTION
# What
cookieにnick_nameを保存
# Why
2回目の以降の投稿時にnick_nameを入力する手間を省くため