### PR TITLE
削除前に確認dialogを追加

### DIFF
--- a/app/views/prompts/_prompt.html.erb
+++ b/app/views/prompts/_prompt.html.erb
@@ -17,7 +17,7 @@
     <button class="content-copy-button">COPY!</button>
     <%if(your_prompt?(prompt))%>
       <%=link_to "編集", edit_prompt_path(prompt.id)%>
-      <%= link_to "削除", prompt_path(prompt.id),data: {turbo_method: :delete}%>
+      <%= link_to "削除", prompt_path(prompt.id),data: { confirm: "本当に削除しますか？" }, method: :delete%>
     <%end%>
   </div>
 </div>


### PR DESCRIPTION
# What
削除実行前に、確認を追加
# Why
誤った削除を防ぐため